### PR TITLE
Refine deleteAll functionality for non-null IDs

### DIFF
--- a/src/main/java/com/example/inovasiyanotebook/service/entityservices/iml/OrderPositionService.java
+++ b/src/main/java/com/example/inovasiyanotebook/service/entityservices/iml/OrderPositionService.java
@@ -69,7 +69,14 @@ public class OrderPositionService implements CRUDService<OrderPosition> {
     }*/
 
     public void deleteAll(List<OrderPosition> entities) {
-        orderPositionRepository.deleteAllInBatch(entities);
+        List<OrderPosition> validEntities = filterEntitiesWithNonNullId(entities);
+        orderPositionRepository.deleteAllInBatch(validEntities);
+    }
+
+    private List<OrderPosition> filterEntitiesWithNonNullId(List<OrderPosition> entities) {
+        return entities.stream()
+                .filter(orderPosition -> orderPosition.getId() != null)
+                .toList();
     }
 
     public void delete(OrderPosition entity) {


### PR DESCRIPTION
<details>
<summary>Details</summary>

- Updated deleteAll to filter out entities with null IDs before batch deletion.
- Ensures a more stable and error-free operation.
  
</details>